### PR TITLE
Add Beginnerbox and Startercollection to PromoType

### DIFF
--- a/src/card/promo_types.rs
+++ b/src/card/promo_types.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 pub enum PromoType {
     Alchemy,
     Arenaleague,
+    Beginnerbox,
     Boosterfun,
     Boxtopper,
     Brawldeck,
@@ -82,6 +83,7 @@ pub enum PromoType {
     Silverfoil,
     Sldbonus,
     Stamped,
+    Startercollection,
     Starterdeck,
     Stepandcompleat,
     Storechampionship,


### PR DESCRIPTION
These PromoType variants are used in the [Foundations (FDN)](https://scryfall.com/sets/fdn) set.